### PR TITLE
Create labeler.yml - configuration for github action to evaluate PR sizes

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,32 @@
+name: labeler
+
+on: [pull_request]
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '10'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '500'
+          l_label: 'size/l'
+          l_max_size: '1000'
+          xl_label: 'size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          github_api_url: 'https://api.github.com'
+          files_to_ignore: ''

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,15 +14,15 @@ jobs:
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_label: 'size/xs'
+          xs_label: 'Size: XS'
           xs_max_size: '10'
-          s_label: 'size/s'
+          s_label: 'Size: S'
           s_max_size: '100'
-          m_label: 'size/m'
+          m_label: 'Size: M'
           m_max_size: '500'
-          l_label: 'size/l'
+          l_label: 'Size: L'
           l_max_size: '1000'
-          xl_label: 'size/xl'
+          xl_label: 'Size: XL'
           fail_if_xl: 'false'
           message_if_xl: >
             This PR exceeds the recommended size of 1000 lines.


### PR DESCRIPTION
**Description**

Added labeler.yml in .github/workflows, with the default settings:

 - no files are ignored when calculating the size
 - deleting lines counts as a change 
 - If the PR exceeds 1000 line changes, the action does not fail. Instead, a message appears. 

