### PR TITLE
[FIX] Update labeler.yml - change trigger to pull_request_target

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: labeler
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   labeler:


### PR DESCRIPTION
The trigger `pull_request` can at most get `read` permissions from forks, thus PRs do not get labelled. 

Using `pull_request_target` fixes it.