### PR TITLE
Fix #24 : add missing JSR-305 dependency to resolve annotation processing …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,14 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION

- Issue: Compilation was generating warnings related to missing class `javax.annotation.meta.When.MAYBE` during annotation processing.
- Cause: The JSR-305 library, which includes the `javax.annotation.meta.When` enum, was not included in the classpath.
- Fix: Added the JSR-305 dependency (version 3.0.2) to the project to resolve the missing class file warnings.

This ensures that annotation processing can complete without warnings and that the required JSR-305 classes are available during the build.

Closes ticket number #24 .