### PR TITLE
Add custom JWT error messages for authentication failures

### DIFF
--- a/src/main/java/dev/nmarulo/depensaapp/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/dev/nmarulo/depensaapp/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package dev.nmarulo.depensaapp.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.nmarulo.depensaapp.commons.dtos.ErrorRes;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    
+    private final AuthenticationEntryPoint delegate = new BearerTokenAuthenticationEntryPoint();
+    
+    private final ObjectMapper mapper;
+    
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        
+        this.delegate.commence(request, response, authException);
+        
+        if (authException instanceof InvalidBearerTokenException bearerTokenException) {
+            var problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED,
+                                                                 bearerTokenException.getMessage());
+            
+            problemDetail.setTitle("Invalid Token");
+            
+            response.setContentType("application/json");
+            
+            mapper.writeValue(response.getWriter(), new ErrorRes(problemDetail));
+        }
+    }
+    
+}

--- a/src/main/java/dev/nmarulo/depensaapp/security/WebSecurityConfig.java
+++ b/src/main/java/dev/nmarulo/depensaapp/security/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package dev.nmarulo.depensaapp.configuration;
+package dev.nmarulo.depensaapp.security;
 
 import com.nimbusds.jose.KeyLengthException;
 import com.nimbusds.jose.crypto.MACSigner;
@@ -8,6 +8,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import dev.nmarulo.depensaapp.app.users.UserRepository;
 import dev.nmarulo.depensaapp.commons.component.LocalMessage;
 import dev.nmarulo.depensaapp.commons.converter.CustomJwtAuthenticationConverter;
+import dev.nmarulo.depensaapp.configuration.AppProperties;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,8 @@ public class WebSecurityConfig {
     private final UserRepository userRepository;
     
     private final LocalMessage localeMessage;
+    
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -105,7 +108,8 @@ public class WebSecurityConfig {
     private Customizer<OAuth2ResourceServerConfigurer<HttpSecurity>> configOAuth2() {
         final var converter = new CustomJwtAuthenticationConverter(this.userRepository, this.localeMessage);
         
-        return oauth -> oauth.jwt(jwtConfigurer -> jwtConfigurer.jwtAuthenticationConverter(converter));
+        return oauth -> oauth.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                             .jwt(jwtConfigurer -> jwtConfigurer.jwtAuthenticationConverter(converter));
     }
     
 }


### PR DESCRIPTION
Fixes #22 
<!-- Issue. Ex: Fixes #1 -->

**Description**
<!-- Please include a summary of the changes you think are relevant to complement the issue. Otherwise, you may refer to the issue only. -->
A custom `AuthenticationEntryPoint` has been implemented named `JwtAuthenticationEntryPoint` which intercepts any JWT Exceptions from the `SecurityFilterChain` and sets up the `ProblemDetails` accordingly  wrapped inside the `ErrorRes` Object . The response content type has been set to "application/json" for increased readability.

**Screenshots**
<!--If applicable-->
